### PR TITLE
Add World Cup 2026 player dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A collection of awesome football (national teams, clubs, match schedules, player
 
 - [Onside World Cup 2026 model outputs](https://onsidearena.com/data) - per-match win/draw probabilities, champion odds (10,000-run Monte Carlo simulation) and the full 104-match schedule as CC BY 4.0 CSVs, refreshed through the tournament; includes a [public graded accuracy record](https://onsidearena.com/world-cup-2026/model-record) and a [Kaggle mirror](https://www.kaggle.com/datasets/wr0027/world-cup-2026-predictions-onside-model-outputs)
 
-
+- [World Cup 2026 Player Data](https://github.com/risingtransfers/world-cup-2026-data) — All 48 squads (1,363 players) with per-90 stats and AI player similarity examples. CC BY 4.0.
 
 ## V2 -  What's News in 2022?
 


### PR DESCRIPTION
Adds an open CC BY 4.0 dataset covering all 48 squads at the 2026 World Cup:
- 1,363 players with nation, position, club, age
- Per-90 performance stats (2025-26 season)
- AI player similarity examples

Timely for the 2026 World Cup; also fills part of the gap left by FBref's advanced-stats removal in Jan 2026.