### PR TITLE
Add World Cup 2026 Tour schedule dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A collection of awesome football (national teams, clubs, match schedules, player
 ### World Cup 2026 
 - [Onside World Cup 2026 model outputs](https://onsidearena.com/data) - model predictions (open data); per-match win/draw probabilities, champion odds (10,000-run Monte Carlo simulation) and the full 104-match schedule as CC BY 4.0 CSVs, refreshed through the tournament; includes a [public graded accuracy record](https://onsidearena.com/world-cup-2026/model-record) and a [Kaggle mirror](https://www.kaggle.com/datasets/wr0027/world-cup-2026-predictions-onside-model-outputs)
 
+- [World Cup 2026 Tour schedule dataset](https://ay-worldcup2026.zeabur.app/dataset) - all 104 fixtures with UTC kickoff times, match pages, CSV/JSONL snapshots, a free local-time JSON API, OpenAPI spec, ICS calendar feed, and [Hugging Face](https://huggingface.co/datasets/abaiii168/world-cup-2026-tour-match-schedule) / [Kaggle](https://www.kaggle.com/datasets/ayworldcup2026/world-cup-2026-tour-match-schedule) mirrors.
+
 - [World Cup 2026 Player Data](https://github.com/risingtransfers/world-cup-2026-data) - all 48 squads (1363 players) with per-90 stats and AI player similarity examples. CC BY 4.0.
 
 ## V2 -  What's News in 2022?
@@ -168,4 +170,3 @@ The awesome list is dedicated to the public domain. Use as you please with no re
 
 Yes, you can. More than welcome.
 See [Help & Support »](https://github.com/openfootball/help)
-


### PR DESCRIPTION
Adds World Cup 2026 Tour as a 2026 schedule dataset/resource.\n\nIt provides all 104 fixtures with UTC kickoff times, match pages, CSV and JSONL snapshots, a free local-time JSON API, OpenAPI spec, ICS calendar feed, and Hugging Face/Kaggle mirrors.\n\nCanonical dataset page: https://ay-worldcup2026.zeabur.app/dataset