### PR TITLE
Add TopScorers (World Cup 2026 live top scorers & Golden Boot)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ A collection of awesome football (national teams, clubs, match schedules, player
 
 - [lefProg/claudial](https://github.com/lefProg/claudial) - a small fun project that lets you see live updates for the 2026 World Cup right in your Claude Code status line.
 
+- [TopScorers World Cup 2026](https://www.top-scorers.com/en/mundial-2026) - live top scorers, assists and the Golden Boot race for the 2026 World Cup, plus group standings, results and the full 104-match schedule. Bilingual (EN/ES), free, no signup.
+
 ## V2 -  What's News in 2022?
 
 


### PR DESCRIPTION
Adds TopScorers to the **World Cup 2026** section.

[TopScorers](https://www.top-scorers.com) tracks live top scorers, assists and the Golden Boot race for the 2026 World Cup, with group standings, results and the full 104-match schedule. Bilingual (EN/ES), free and no signup — in the same spirit as the other WC2026 live trackers/dashboards already listed. Built by Furiosa Studio.