### PR TITLE
⚽ Add Non-League Match Day Culture & Fan Community Discussions (DUPLICATE)

### DIFF
--- a/NON-LEAGUE-MATCH-DAY-CULTURE.md
+++ b/NON-LEAGUE-MATCH-DAY-CULTURE.md
@@ -1,0 +1,35 @@
+# Non-League Match Day Culture
+
+The English non-league pyramid (National League down to local county tiers) offers a match day experience that is intimate, affordable, and refreshingly honest — a world away from the glitz of the Premier League.
+
+Drawing on fan community discussions and match day tradition research, here is what makes these games special:
+
+## Pie, Mash & Gravy
+
+The "Footy Scran" revolution has seen clubs partner with local bakeries to serve legendary steak and ale pies with creamy mash and rich gravy. Stadium dining in the lower leagues is a proper event, not an afterthought — a proper football scran that warms you up on a chilly Tuesday night under the floodlights. ([Non-League Football Paper](https://www.thenonleaguefootballpaper.com/guest-posts/604687/the-perfect-matchday-a-beginners-guide-to-the-non-league-experience/))
+
+## The Social Club
+
+Every ground has its own clubhouse or social club where the community truly gathers. Unlike the sterile environments of high-end hospitality, these are welcoming hubs where fans, club officials, and sometimes even the players mingle freely over a drink for a fraction of the price you would pay downtown. It provides a sense of belonging, making you feel like a member of a family rather than just a customer. ([Match Centre UK](https://matchcentre.co.uk/blog/optimising-the-fan-experience-a-practical-guide-for-non-league-clubs))
+
+## The Physical Programme
+
+In an increasingly digital world, buying a couple of pounds matchday programme is one of the last tangible traditions. It directly supports the club's finances and offers unique local history, manager notes, and player interviews. There is something uniquely satisfying about leafing through a paper programme while standing on a terrace, checking the lineups as the players walk onto the pitch.
+
+## Freedom of the Terrace
+
+No assigned seats, no barriers — fans can stand wherever they like and even "change ends" at half-time to stay behind the goal their team is attacking. You're close enough to hear the crunch of a tackle and the shouts of the keeper. There are no VAR delays, and no barrier between you and the action. It is football in its purest form.
+
+## Community Over Commerce
+
+Well-behaved dogs are often allowed at non-league grounds, alcohol can be drunk in view of the pitch (a unique selling point of the lower leagues), and supporters are welcomed as people, not customers. Fans decide whether to attend based on what the day represents, not just the opposition or the league table. ([Fanbase](https://fanbaseclub.com/theclubhouse/matchday-experience-drives-attendance))
+
+## Tech-Savvy Traditionalists
+
+Even at rural grounds with a single wooden stand, fans in 2026 are more connected than ever — checking live stats on their phones, following the "as it stands" league table during half-time, and bridging the gap between grassroots passion and digital engagement.
+
+## Sources
+
+- [The Non-League Football Paper — The Perfect Matchday](https://www.thenonleaguefootballpaper.com/guest-posts/604687/the-perfect-matchday-a-beginners-guide-to-the-non-league-experience/)
+- [Match Centre UK — Optimising the Fan Experience](https://matchcentre.co.uk/blog/optimising-the-fan-experience-a-practical-guide-for-non-league-clubs)
+- [Fanbase — Matchday Experience Drives Attendance](https://fanbaseclub.com/theclubhouse/matchday-experience-drives-attendance)


### PR DESCRIPTION
## Add Non-League Match Day Culture summary

This PR adds a new documentation file summarising match day experiences and traditions from the English non-league pyramid (National League down to local county tiers), based on community discussions and research.

### What's covered:

- **Pie, Mash & Gravy** — The "Footy Scran" revolution, local bakery partnerships, stadium dining as a proper event
- **The Social Club** — Community gathering hubs where fans, officials, and players mingle freely
- **The Physical Programme** — Matchday programmes as a cherished physical tradition supporting club finances
- **Freedom of the Terrace** — No assigned seats, ability to change ends at half-time, proximity to the action
- **Community Over Commerce** — Dogs allowed, alcohol in view of the pitch, fans welcomed as people not customers
- **Tech-Savvy Traditionalists** — How modern fans blend grassroots passion with digital engagement

### Sources:

- [The Non-League Football Paper — The Perfect Matchday](https://www.thenonleaguefootballpaper.com/guest-posts/604687/the-perfect-matchday-a-beginners-guide-to-the-non-league-experience/)
- [Match Centre UK — Optimising the Fan Experience](https://matchcentre.co.uk/blog/optimising-the-fan-experience-a-practical-guide-for-non-league-clubs)
- [Fanbase — Matchday Experience Drives Attendance](https://fanbaseclub.com/theclubhouse/matchday-experience-drives-attendance)

This aligns with the project's goal of collecting awesome football resources, extending beyond datasets to capture the cultural/volunteer-driven side of the game that makes non-league football unique.

Fixes #(none) — new content addition.