### PR TITLE
Add Scorewit to Football Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ _Open source apps for match scores, picks, predictions, office pools, and more_
 - [chrenkot/Austrian-Bundesliga :octocat:](https://github.com/chrenkot/Austrian-Bundesliga) - a little open source android app for gathering information about the austrian bundesliga
 - [rodmoioliveira/football-graphs :octocat:](https://github.com/rodmoioliveira/football-graphs) - Some visualizations on passing networks
 * [Last season comparison](https://compare-last-season.netlify.app), [:octocat:](https://github.com/nurgasemetey/compare-last-season) - Last season comparison tool
+- [Scorewit](https://www.scorewit.com) - free daily football trivia plus computed World Cup and English top-flight reference pages, built on openfootball worldcup + england data (attribution: https://www.scorewit.com/llms.txt)
 
 
 


### PR DESCRIPTION
Adds one entry to the Football Apps section: [Scorewit](https://www.scorewit.com) — free daily football trivia (six fact-checked questions per day) plus computed reference pages for World Cup history (/worldcup and /team, /wc, /h2h pages) and the English top flight (/topflight), all built on openfootball's worldcup and england datasets.

Every fact is machine-verified against the dataset before publish, and every page footer credits openfootball; the data sources and licenses for the whole site are documented at https://www.scorewit.com/llms.txt. Thanks for the datasets — happy to adjust the entry wording or placement to fit the list's conventions.