### PR TITLE
Add korean-football-team-names dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ _Where's the open football data?_
 
 ## Football Datasets
 
+- [korean-football-team-names :octocat:](https://github.com/dwoony0909-tech/korean-football-team-names) - English → Korean club name mapping for 264 European clubs (CC0), keyed on football-data.org names
+
 ### World Cup
 
 - [openfootball/world-cup :octocat:](https://github.com/openfootball/world-cup)


### PR DESCRIPTION
Add korean-football-team-names dAn English-to-Korean name mapping for 264 European football clubs, keyed on the
club names returned by the football-data.org API. Covers the top five leagues and
their second divisions plus UEFA Champions League opponents.

- JSON + CSV, with a Frictionless datapackage descriptor
- CC0 1.0 (public domain)
- Archived on Zenodo: https://doi.org/10.5281/zenodo.21884267
- Also on npm: korean-football-team-namesataset