### PR TITLE
Add settled football predictions dataset (Football Datasets / Misc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ _Where's the open football data?_
 - [llimllib/soccerdata :octocat:](https://github.com/llimllib/soccerdata) - a collection of soccer results
 - [milkysunshine91/sport_db.Football :octocat:](https://github.com/milkysunshine91/sport_db.Football) - general purpose football database
 - [orlandoaleman/FootballAppResources :octocat:](https://github.com/orlandoaleman/FootballAppResources)
+- [Football Betting Predictions - Fully Settled Log (Kaggle)](https://www.kaggle.com/datasets/aibettingtips/football-betting-predictions-fully-settled-log) - football predictions settled against real final scores (losses included) with odds, closing odds and closing-line value per pick; CC BY 4.0
  
 
 ## Stadium Datasets


### PR DESCRIPTION
Adds a CC BY 4.0 Kaggle dataset of football predictions settled against real final scores — losses included, with closing odds and closing-line value per pick, plus the final-score archive used for settlement.

Disclosure: I publish this dataset. Submitting it because fully settled prediction logs (losses included, with closing odds) are rare — most public tipster data suffers from survivorship bias.