### PR TITLE
Add Matchday Passport to Football Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ _Open source apps for match scores, picks, predictions, office pools, and more_
 - [rodmoioliveira/football-graphs :octocat:](https://github.com/rodmoioliveira/football-graphs) - Some visualizations on passing networks
 * [Last season comparison](https://compare-last-season.netlify.app), [:octocat:](https://github.com/nurgasemetey/compare-last-season) - Last season comparison tool
 - [Scorewit](https://www.scorewit.com) - free daily football trivia plus computed World Cup and English top-flight reference pages, built on openfootball worldcup + england data (attribution: https://www.scorewit.com/llms.txt)
+- [Matchday Passport](https://allenwu-blip.github.io/matchday-passport/) - free iOS app that turns every match you attend into a collectible passport stamp (ground, date, score, both nations' flags, a different ink per competition); fixtures across twelve competitions sync daily from [football-data.org](https://www.football-data.org) with in-app attribution, and every fixture gets a page where fans who were there share photos and video; no ads, tracking or analytics; [App Store](https://apps.apple.com/us/app/matchday-passport/id6792546917)
 
 
 


### PR DESCRIPTION
Matchday Passport is a free iOS app that turns matches you attend into collectible passport stamps, with a page per fixture where fans who were there share photos and video. Fixtures across twelve competitions sync daily from football-data.org, with attribution shown in the app. It is free with no ads, tracking or analytics; one line added at the end of the Football Apps section.